### PR TITLE
basic changes for tabular format

### DIFF
--- a/conda_build/build.py
+++ b/conda_build/build.py
@@ -27,7 +27,7 @@ import hashlib
 import encodings.idna  # NOQA
 
 # used to get version
-from .conda_interface import cc
+from .conda_interface import cc, text_type
 from .conda_interface import envs_dirs, root_dir
 from .conda_interface import plan
 from .conda_interface import get_index
@@ -529,14 +529,11 @@ def create_info_files_json_v1(m, info_dir, prefix, files, files_with_prefix):
     files_json_fields = ["path", "sha256", "size_in_bytes", "node_type", "file_mode",
                          "prefix_placeholder", "no_link", "inode_paths"]
     files_json_files = build_info_files_json(m, prefix, files, files_with_prefix)
-    files_json_info = {
-        "version": 1,
-        "fields": files_json_fields,
-        "files": files_json_files,
-    }
-    with open(join(info_dir, 'files.json'), "w") as files_json:
-        json.dump(files_json_info, files_json, sort_keys=True, indent=2, separators=(',', ': '),
-                  cls=EntityEncoder)
+    row = lambda path: '|'.join(text_type(path.get(field, '')) for field in files_json_fields)
+    rows = [row(file) for file in files_json_files]
+    rows.insert(0, '|'.join(files_json_fields))
+    with open(join(info_dir, 'PATHS'), "w") as fh:
+        fh.write('\n'.join(rows))
 
 
 def get_build_index(config, clear_cache=True):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -217,24 +217,17 @@ def test_create_info_files_json(testing_workdir, test_metadata):
     files = ["one", "two", "foo"]
 
     build.create_info_files_json_v1(test_metadata, info_dir, testing_workdir, files, files_with_prefix)
-    files_json_path = os.path.join(info_dir, "files.json")
-    expected_output = {
-        "files": [{"file_mode": "text", "node_type": "hardlink", "path": "foo",
-                     "prefix_placeholder": "prefix/path",
-                     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                     "size_in_bytes": 0},
-                    {"node_type": "hardlink", "path": "one",
-                     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                     "size_in_bytes": 0},
-                    {"node_type": "hardlink", "path": "two",
-                     "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                     "size_in_bytes": 0}],
-        "fields": ["path", "sha256", "size_in_bytes", "node_type", "file_mode",
-                   "prefix_placeholder", "no_link", "inode_paths"],
-        "version": 1}
+    files_json_path = os.path.join(info_dir, "PATHS")
+    expected_output = [
+        ["path", "sha256", "size_in_bytes", "node_type", "file_mode", "prefix_placeholder", "no_link", "inode_paths"],
+        ["foo", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "text", "prefix/path", "", ""],
+        ["one", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "", "", "", ""],
+        ["two", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "", "", "", ""],
+    ]
     with open(files_json_path, "r") as files_json:
-        output = json.load(files_json)
-        assert output == expected_output
+        data = files_json.read()
+    output = [row.split('|') for row in data.split('\n')]
+    assert output == expected_output
 
 
 @pytest.mark.skipif(on_win and sys.version[:3] == "2.7",
@@ -254,24 +247,15 @@ def test_create_info_files_json_no_inodes(testing_workdir, test_metadata):
     files = ["one", "two", "one_hl", "foo"]
 
     build.create_info_files_json_v1(test_metadata, info_dir, testing_workdir, files, files_with_prefix)
-    files_json_path = os.path.join(info_dir, "files.json")
-    expected_output = {
-        "files": [{"file_mode": "text", "node_type": "hardlink", "path": "foo",
-                   "prefix_placeholder": "prefix/path",
-                   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "size_in_bytes": 0},
-                  {"node_type": "hardlink", "path": "one",
-                   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "size_in_bytes": 0},
-                  {"node_type": "hardlink", "path": "one_hl",
-                   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "size_in_bytes": 0},
-                  {"node_type": "hardlink", "path": "two",
-                   "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "size_in_bytes": 0}],
-        "fields": ["path", "sha256", "size_in_bytes", "node_type", "file_mode",
-                   "prefix_placeholder", "no_link", "inode_paths"],
-        "version": 1}
+    files_json_path = os.path.join(info_dir, "PATHS")
+    expected_output = [
+        ["path", "sha256", "size_in_bytes", "node_type", "file_mode", "prefix_placeholder", "no_link", "inode_paths"],
+        ["foo", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "text", "prefix/path", "", ""],
+        ["one", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "", "", "", ""],
+        ["one_hl", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "", "", "", ""],
+        ["two", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "0", "hardlink", "", "", "", ""],
+    ]
     with open(files_json_path, "r") as files_json:
-        output = json.load(files_json)
-        assert output == expected_output
+        data = files_json.read()
+    output = [row.split('|') for row in data.split('\n')]
+    assert output == expected_output


### PR DESCRIPTION

    path|sha256|size_in_bytes|node_type|file_mode|prefix_placeholder|no_link|inode_paths
    foo|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|0|hardlink|text|prefix/path||
    one|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|0|hardlink||||
    two|e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|0|hardlink||||

.

    {
      "fields": [
        "path",
        "sha256",
        "size_in_bytes",
        "node_type",
        "file_mode",
        "prefix_placeholder",
        "no_link",
        "inode_paths"
      ],
      "files": [
        {
          "file_mode": "text",
          "node_type": "hardlink",
          "path": "foo",
          "prefix_placeholder": "prefix/path",
          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
          "size_in_bytes": 0
        },
        {
          "node_type": "hardlink",
          "path": "one",
          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
          "size_in_bytes": 0
        },
        {
          "node_type": "hardlink",
          "path": "two",
          "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
          "size_in_bytes": 0
        }
      ],
      "version": 1
    }
